### PR TITLE
Add MQTT outside connection configuration to EMBER Chirpstack v4 

### DIFF
--- a/ember/chirpstack-v4-installation.md
+++ b/ember/chirpstack-v4-installation.md
@@ -181,6 +181,22 @@ sudo journalctl -u chirpstack -f
 sudo journalctl -u chirpstack-gateway-bridge -f
 ```
 
+### Allow outside connections to MQTT broker
+
+:::info
+
+Mainly for testing and debug purposes
+
+:::
+
+- Edit the mosquitto config file in `/etc/mosquitto/mosquitto.conf`:  
+  Add to the bottom:  
+  ```
+  listener 1883
+  allow_anonymous true
+  ```
+
+
 ## Post-Installation Checklist
 
 ### Access the ChirpStack Web Interface


### PR DESCRIPTION
Add configuration for Mosquitto into EMBER/Chirpstack v4 Installation to allow outside connections