### PR TITLE
EMBER docs: the two internal antennas, and how to switch to an external one

### DIFF
--- a/ember/getting-started.md
+++ b/ember/getting-started.md
@@ -20,8 +20,10 @@ EMBER is an industrial **LoRaWAN gateway (IoT Hotspot)** based on **MikroTik RBM
 Hardware description: https://docs.hardwario.com/ember/hardware-description/
 
 #### You will need
-- EMBER gateway (Hotspot)
-- **LoRaWAN antenna** (required)
+- EMBER gateway (Hotspot) — its **LoRaWAN and LTE antennas are already fitted inside** and connected from
+  the factory, so there is no antenna to attach
+- *(Optional)* an **external LoRaWAN antenna** with an N-type connector, if the internal one will not give
+  you the range you need — ordered separately, and fitting it means opening the enclosure
 - Power source:
   - 24 V DC adapter / 24 V DC power supply, or
   - 24 V DC passive PoE via the **WAN** port
@@ -38,11 +40,26 @@ Hardware description: https://docs.hardwario.com/ember/hardware-description/
 
 ## Step 1: Set up your EMBER
 
-#### 1.1 Attach antennas (important)
-- **Attach the LoRaWAN antenna before powering on.**
-- If your unit includes LTE, it may use **two LTE antennas** (internal/external depending on configuration).
+#### 1.1 Antennas — already connected
 
-More details: https://docs.hardwario.com/ember/hardware-description/#antennas
+EMBER arrives with **two antennas fitted inside the enclosure** — one for **LoRaWAN**, one for **LTE** —
+both connected at the factory. **There is nothing to attach**, and the radio is never left without an
+antenna, so you can power the gateway straight up.
+
+An **external** antenna is optional. Because the internal antenna occupies the card's u.FL connector,
+fitting one means opening the enclosure and moving that plug onto the **LRW** connector's pigtail — see
+[Switching to an external antenna](hardware-description.md#switching-to-an-external-antenna).
+
+Whichever antenna is in use, set **`antenna-gain`** in RouterOS to that antenna's gain. Left at the wrong
+value the gateway radiates outside the legal EIRP limit — see
+[Antenna Gain & Output Power](mikrotik/antenna-gain.md).
+
+:::caution If you open the enclosure
+Never power the gateway with the LoRa card's u.FL connector left empty — transmitting into an open
+connector can damage the card. Reseal the enclosure carefully; its **IP67** rating depends on it.
+:::
+
+More details: [Hardware Description → Antennas](hardware-description.md#antennas)
 
 #### 1.2 Power the gateway
 EMBER can be powered by:
@@ -175,10 +192,14 @@ After reconnecting following the reboot, paste this script in the terminal to co
 ```
 
 **What this script does:**
-- Sets the LoRa antenna to use the uFL connector
 - Removes any preconfigured LoRaWAN Network Server (LNS) entries
 
 Press **Enter** to execute.
+
+The LoRa interface itself — including the `antenna=uFL` selection and the `antenna-gain` value for the
+antenna you attached — is set together with your backend. See
+[Hotspot Configuration → LoRaWAN](hotspot-configuration.md#lorawan) and
+[Antenna Gain & Output Power](mikrotik/antenna-gain.md).
 
 ### 3.5 Upgrade RouterBOARD
 In the left panel, go to **System → RouterBOARD** and click **Upgrade**. A new window will open, click **OK**.
@@ -258,7 +279,7 @@ Reference: https://docs.hardwario.com/ember/hotspot-configuration/
 
 ## Step 5: Summary checklist
 
-- LoRaWAN antenna attached (required)
+- An antenna is connected to the LoRa card — the internal one from the factory, or an external one on **LRW**
 - Power connected (24 V DC or 24 V passive PoE via WAN)
 - Outdoor installation: connectors facing down
 - PC connected to **WAN**, receives DHCP lease, can reach `172.31.255.1` (updated from default)
@@ -267,6 +288,7 @@ Reference: https://docs.hardwario.com/ember/hotspot-configuration/
 - RouterOS updated to latest version
 - IoT package installed
 - LoRa interface configured (antenna set to uFL)
+- `antenna-gain` set to the gain of the attached antenna ([why this matters](mikrotik/antenna-gain.md))
 - Bootloader updated
 - Gateway is configured to your backend (HARDWARIO managed / ChirpStack / TTS / other)
 - In the LoRaWAN server UI, gateway status shows **Last seen / connected**

--- a/ember/hardware-description.md
+++ b/ember/hardware-description.md
@@ -22,8 +22,43 @@ The enclosure and connectors are **water-proof and dust-proof**, providing **IP6
 The device is equipped with high-quality connectors for power, networking, and wireless communication.
 
 ### Antennas
-- **LRW (LoRaWAN):** One N-type connector for the LoRa antenna. Required for gateway operation.
+- **LRW (LoRaWAN):** One N-type connector for an **optional external** LoRa antenna.
 - **LTE1 & LTE2:** Two connectors for LTE antennas (Main and Diversity). Used if the LTE modem is installed to provide cellular backhaul (supports 2G / 3G / 4G).
+
+#### EMBER ships with two internal antennas
+
+Every EMBER leaves the factory with **two antennas fitted inside the enclosure and already connected** —
+one for **LoRaWAN** (on the LoRa card's `RFIO` u.FL connector) and one for **LTE**. The radio therefore
+always has an antenna on it when you unbox the gateway: it is safe to power on, and **nothing has to be
+screwed on before you start**.
+
+The package contains the **24 V DC power adapter** and no loose antennas — see
+[Ordering Codes](ordering-codes.md).
+
+#### Switching to an external antenna
+
+The **LRW**, **LTE1** and **LTE2** connectors on the enclosure are there for **optional external
+antennas** — worth fitting when you need more range than the internal antenna delivers, or when the
+gateway is mounted somewhere that shields it. The internal antenna occupies the card's u.FL connector, so
+switching over is a manual step:
+
+1. **Disconnect power.**
+2. Open the enclosure.
+3. Unplug the internal antenna from the card's u.FL connector (`RFIO` on the LoRa card) and plug the
+   pigtail of the matching bulkhead connector (**LRW** for LoRaWAN) in its place.
+4. Close the enclosure and screw the external antenna onto the connector.
+5. Update **`antenna-gain`** in RouterOS to the gain of the antenna now in use — see
+   [Antenna Gain & Output Power](mikrotik/antenna-gain.md). Left at the value for the old antenna, the
+   gateway radiates above or below the legal EIRP limit.
+
+:::caution
+Close the enclosure carefully — the **IP67** rating depends on its seal. And never power the gateway with
+the LoRa card's u.FL connector left empty: transmitting into an open connector can damage the card's power
+amplifier.
+:::
+
+If you have the enclosure open and need to tell the cards apart: the **LoRa card has a single u.FL
+connector** (`RFIO`), while the **LTE card has two** (`MAIN` and `AUX`).
 
 ### Power and Data
 - **DC IN:** Circular industrial connector for external 24 V DC power supply.

--- a/ember/mikrotik/antenna-gain.md
+++ b/ember/mikrotik/antenna-gain.md
@@ -108,8 +108,10 @@ documentation: [LoRa General Properties](https://help.mikrotik.com/docs/spaces/R
 /lora set [find] antenna-gain=2
 ```
 
-> On newer RouterOS builds the menu may be `/iot lora` instead of `/lora`. If `/lora`
-> is not found, use `/iot lora set [find] antenna-gain=2`.
+:::info
+On newer RouterOS builds the menu may be `/iot lora` instead of `/lora`. If `/lora` is not found, use
+`/iot lora set [find] antenna-gain=2`.
+:::
 
 ---
 
@@ -120,6 +122,10 @@ documentation: [LoRa General Properties](https://help.mikrotik.com/docs/spaces/R
 | wAP LR8G kit built-in antenna (868 MHz) | 2 dBi | `2` |
 | MikroTik omni LoRa antenna kit (`TOF-0809-...`) | 6.5 dBi | `6.5` |
 | Other external antenna | see its datasheet | antenna dBi − cable loss |
+
+On **EMBER** the value has to match whichever antenna is actually connected to the LoRa card — the
+internal LoRaWAN antenna it ships with, or an external antenna on the **LRW** connector (its gain minus the
+loss of the cable between them). Update the setting whenever you switch between the two.
 
 If the antenna gain is unknown, err on the **higher** side — the gateway will back off
 its power further and stay within legal limits.
@@ -149,10 +155,10 @@ firmware or ADR from the server), not the gateway.
 To increase real-world range, use a better antenna and/or shorter, lower-loss cable —
 then update `antenna-gain` accordingly. The setting itself never adds power.
 
-:::caution wAP LR8G kit — connect the internal antenna first
-On the wAP LR8G kit the internal antenna is **not connected from the factory**. Attach
-it to the card's **RFIO** u.FL connector (with the device powered off) before use, or
-the card cannot transmit or receive over the antenna at all.
+:::caution MikroTik wAP LR8G kit — connect the internal antenna first
+On MikroTik's standalone **wAP LR8G kit**, the internal antenna is **not connected from the factory**.
+Attach it to the card's **RFIO** u.FL connector (with the device powered off) before use, or the card
+cannot transmit or receive over the antenna at all.
 :::
 
 ---

--- a/ember/ordering-codes.md
+++ b/ember/ordering-codes.md
@@ -18,7 +18,12 @@ Each product lists available parts, i.e. which parts are standard and usually im
 
 :::info
 
-The product always includes a 24 V DC power adapter with international plugs.
+The product always includes a **24 V DC power adapter** with international plugs.
+
+The **LoRaWAN and LTE antennas are fitted inside the enclosure** and connected at the factory, so no
+antenna has to be ordered to put a gateway on the air. **External antennas are not part of the package** —
+order them separately, and note that fitting one means opening the enclosure. See
+[Hardware Description → Antennas](hardware-description.md#antennas).
 
 :::
 


### PR DESCRIPTION
## Why

The EMBER docs told the reader to obtain and attach a LoRaWAN antenna before powering the gateway on, and
said nothing about the antennas already inside it. Confirmed with hardware: **every EMBER ships with two
antennas fitted inside the enclosure and connected at the factory** — one for **LoRaWAN** (on the LoRa
card's `RFIO` u.FL) and one for **LTE**. Nothing has to be attached, and the radio is never left open.

The docs also never described what moving to an external antenna actually involves, which is opening the
enclosure and re-seating a u.FL plug.

## What changed

- **Quick Start**, **Hardware Description**, **Ordering Codes**: both antennas are internal and connected
  from the factory. The LoRaWAN antenna is no longer listed as a prerequisite — it is an optional upgrade.
- **New: "Switching to an external antenna."** Power off → open the enclosure → move the card's u.FL plug
  from the internal antenna onto the **LRW** bulkhead pigtail → reseal → update `antenna-gain`. With
  cautions for the IP67 seal and for never powering the card with an empty u.FL connector.
- **Scoped the wAP LR8G kit caution** to MikroTik's standalone kit by name. Sitting unscoped in the EMBER
  doc set, "the internal antenna is not connected from the factory" implied EMBER behaves the same way.
- **`antenna-gain`** must match whichever antenna is connected; the page is now linked from the Quick Start
  and its checklist.
- **Fixed Step 3.4**, which claimed its script sets `antenna=uFL`. The script only removes LNS entries.
- **Style:** converted the RouterOS menu note on the antenna-gain page from a markdown blockquote to an
  `:::info` admonition, matching the rest of the doc set.

## One open item before merge

The paragraph added under **Recommended values** on the antenna-gain page ("On EMBER the value has to match
whichever antenna is actually connected…") is deliberately unspecific, because **the internal LoRaWAN
antenna's gain is not documented anywhere**. It would be better as a row in the existing table once that
figure is known — `EMBER internal LoRaWAN antenna | X dBi | X`. Happy to strip the paragraph before merge
if you would rather wait for the number.

Related: whether stock units need `antenna-gain` changed at all depends on what configuration EMBER was
certified with under EN 300 220-2 — this PR deliberately does not tell anyone to change the factory
default, only to set it when fitting an external antenna.

## Verification

`npm run build` passes with `onBrokenLinks: 'throw'`; the new `#switching-to-an-external-antenna` anchor and
the Quick Start link to it are present in the built HTML.
