### PR TITLE
Add a HARDWARIO Manager quick start to the Apps docs

### DIFF
--- a/apps/hardwario-manager/first-steps.md
+++ b/apps/hardwario-manager/first-steps.md
@@ -1,0 +1,61 @@
+---
+slug: first-steps
+title: Quick Start Guide
+---
+
+# HARDWARIO Manager Quick Start Guide
+
+**HARDWARIO Manager** is the HARDWARIO mobile app for setting up devices in the field. Hold your phone against a device (or connect to it wirelessly) to read its information, write its configuration, run device commands, and keep a list of the devices you manage — no cables, programmers, or desktop software required.
+
+The app reaches a device over one of two wireless links, depending on the product:
+
+| Link | Used by | Notes |
+|---|---|---|
+| **NFC** | STICKER | Works even with **no batteries inserted** (NFC energy harvesting), so a device can be prepared before it is installed. Needs an **Android** phone with NFC. |
+| **Bluetooth Low Energy** | FIBER | Provisioning and configuration over a paired Bluetooth connection. |
+
+---
+
+## 1) Install the app
+
+| Platform | Download |
+|---|---|
+| **Android** | [**Google Play**](https://play.google.com/store/apps/details?id=com.hardwario.manager) |
+| **iOS** | [**App Store**](https://apps.apple.com/app/id6444803082) |
+
+Updates arrive automatically through the store, and your saved devices are kept across updates.
+
+:::info STICKER is configured from Android
+STICKER configuration over NFC is done from an **Android phone with NFC** (most phones from the last few years have it).
+:::
+
+---
+
+## 2) Turn on the wireless link
+
+- **NFC** — open **Settings**, type **NFC** in the search box at the top, then switch it **On**. There is no in-app permission prompt for NFC.
+- **Bluetooth** — switch Bluetooth on and tap **Allow** when the app asks for the **Nearby devices** permission.
+
+The app also asks for the **Camera** permission, but only the first time you scan a QR code.
+
+---
+
+## 3) Open the app and pick your device
+
+<img src="/img/hw-manager/hw-manager-landing-page.jpg" alt="HARDWARIO Manager home screen listing the supported device families" width="320" />
+
+1. Open **HARDWARIO Manager** and choose the device family you are working with.
+2. Pick what you want to do — for example **Device info** or **Configuration**.
+3. When the screen says *Hold the phone against the …*, touch the back of your phone to the device and keep still for a second or two.
+
+The NFC antenna is usually near the **top back** of the phone. If nothing happens, move the phone slowly around that area until it reads.
+
+---
+
+## 4) Continue with your device guide
+
+Each product documents what HARDWARIO Manager can do with it:
+
+| Device | Guide |
+|---|---|
+| **STICKER** | [**Set up STICKER over NFC →**](/sticker/nfc-configurator-app/nfc-configurator-setup) |

--- a/apps/introduction.md
+++ b/apps/introduction.md
@@ -12,6 +12,12 @@ These applications visualize and process data from HARDWARIO devices. The table 
 
 ---
 
+## HARDWARIO Manager
+
+**[HARDWARIO Manager](/apps/hardwario-manager/first-steps)** is the HARDWARIO mobile app for setting devices up in the field over NFC or Bluetooth Low Energy — the step before their data reaches any of the platforms below.
+
+---
+
 | Platform | Web | Difficulty | Description |
 |----------|-----|------------|-------------|
 | **[Ubidots](/apps/ubidots/index)** | [Website](https://ubidots.hardwario.com/) | Easy | Cloud IoT platform with simple dashboards, alerts, and fast setup. |

--- a/sidebars-apps.js
+++ b/sidebars-apps.js
@@ -6,6 +6,14 @@ const sidebars = {
     'introduction',
     {
       type: 'category',
+      label: 'HARDWARIO Manager',
+      collapsed: true,
+      items: [
+        'hardwario-manager/first-steps',
+      ],
+    },
+    {
+      type: 'category',
       label: 'Ubidots',
       link: {
         type: 'doc',


### PR DESCRIPTION
The **Apps** doc set covered only third-party data platforms (Ubidots, ThingsBoard, ChirpStack, The Things Stack), so the app we ship ourselves had no entry point there — HARDWARIO Manager was documented only inside STICKER's sidebar, where nobody looking for *the app* would find it.

### What this adds

- **`apps/hardwario-manager/first-steps.md`** → `/apps/hardwario-manager/first-steps` — what the app is, which wireless link it uses per product (NFC → STICKER, BLE → FIBER), the Google Play / App Store downloads, the permissions it asks for, and the first run (reusing the existing `/img/hw-manager/hw-manager-landing-page.jpg` screenshot).
- A **HARDWARIO Manager** category in `sidebars-apps.js`, placed first after *Introduction*.
- A short block on the Apps landing page (`apps/introduction.md`) so `/apps/` and the sidebar agree. The platform table is untouched — Manager configures devices rather than visualizing their data, so it reads as its own thing.

The closing *Continue with your device guide* table has one row for now — **STICKER**, pointing at `/sticker/nfc-configurator-app/nfc-configurator-setup`. Further rows (FIBER, and CHESTER's Bluetooth flow at `/chester/hardwario-manager`) can be added as those pages are reviewed.

### Verification

- `npm run build` passes — `onBrokenLinks: 'throw'`, so both the cross-instance STICKER link and the landing-page link are confirmed to resolve.
- Rendered from `npm run serve` and checked in the browser: sidebar entry, both tables, the screenshot, and the STICKER link all render as intended.
- Both store URLs return 200 (the App Store link is the country-neutral `apps.apple.com/app/id6444803082`, which redirects to the visitor's store).